### PR TITLE
Fix calendar duplication bug

### DIFF
--- a/app/views/calendars/index.html.haml
+++ b/app/views/calendars/index.html.haml
@@ -73,7 +73,10 @@
         }).get().join(',');
       var calendar_url = '/event_instances.json?calendar_ids=' + viewable_calendars;
       var new_event_link = "#{new_event_path}"
-      $('#calendar').fullCalendar({
+
+      var calendarElement = $('#calendar');
+      calendarElement.fullCalendar('destroy'); // remove current calendar from DOM before reinstantiating it
+      calendarElement.fullCalendar({
         dayClick: function(date, allDay, jsEvent, view) {
           document.location.href=new_event_link + "?start_date=" + date;
         },


### PR DESCRIPTION
This commit makes sure the visual calendar has been cleared from the DOM
before refreshing it. This fixes the issue where the calendar would
duplicate itself every time a calendar's visibility was toggled (or in
any other occasion when the calendar needed to be reloaded).
